### PR TITLE
Feat/2 게시판 기능 추가

### DIFF
--- a/src/main/java/com/nemo/dong_geul_be/board/controller/BoardDGController.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/controller/BoardDGController.java
@@ -1,0 +1,69 @@
+package com.nemo.dong_geul_be.board.controller;
+
+import com.nemo.dong_geul_be.board.domain.dto.request.CreatePostRequest;
+import com.nemo.dong_geul_be.board.domain.dto.response.PostDTO;
+import com.nemo.dong_geul_be.board.domain.dto.response.PostDetailResponse;
+import com.nemo.dong_geul_be.board.domain.entity.Comment;
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import com.nemo.dong_geul_be.board.service.CommentService;
+import com.nemo.dong_geul_be.board.service.PostService;
+import com.nemo.dong_geul_be.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/donggeul")
+@RequiredArgsConstructor
+public class BoardDGController {    //동글동글 : 동아리 홍보
+
+    private final PostService postService;
+    private final CommentService commentService;
+
+    // 메인페이지
+    @GetMapping("")
+    public Response<List<PostDTO>> getFalsePostTypePosts() {
+        List<PostDTO> posts = postService.getFalsePostTypePosts();
+        return Response.ok(posts);
+    }
+
+    // 동글동글, 교내
+    @GetMapping("/on")
+    public Response<List<PostDTO>> getPostFalseExternalFalsePosts() {
+        List<PostDTO> posts = postService.getPostFalseExternalFalsePosts();
+        return Response.ok(posts);
+    }
+
+    // 동글동글, 교외
+    @GetMapping("/off")
+    public Response<List<PostDTO>> getPostFalseExternalTruePosts() {
+        List<PostDTO> posts = postService.getPostFalseExternalTruePosts();
+        return Response.ok(posts);
+    }
+
+    // 게시글 상세보기
+    @GetMapping("/{postId}")
+    public Response<PostDetailResponse> getPostDetails(@PathVariable Long postId) {
+        Post post = postService.getPostById(postId);
+        List<Comment> comments = commentService.getCommentsByPost(postId);
+
+        PostDetailResponse response = new PostDetailResponse(post, comments);
+        return Response.ok(response);
+    }
+
+    // 글 작성
+    @PostMapping("/create")
+    public Response<Post> createDonggeulPost(@RequestBody CreatePostRequest createPostRequest) {
+        Post newPost = postService.createDonggeulPost(createPostRequest);
+        return Response.ok(newPost);
+    }
+
+    // 댓글 작성
+    @PostMapping("/{postId}/comment")
+    public Response<Comment> createComment(@PathVariable Long postId, @RequestBody String content) {
+        Comment newComment = commentService.createComment(postId, content);
+        return Response.ok(newComment);
+    }
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/controller/BoardJJController.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/controller/BoardJJController.java
@@ -1,0 +1,28 @@
+package com.nemo.dong_geul_be.board.controller;
+
+
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import com.nemo.dong_geul_be.board.service.PostService;
+import com.nemo.dong_geul_be.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/jejal")
+@RequiredArgsConstructor
+public class BoardJJController {    //재잘재잘 : 자유게시판
+
+    private final PostService postService;
+
+    //메인페이지
+    @GetMapping("") // 재잘재잘은 booelean이 1인 게시글
+    public Response<List<Post>> getTruePostTypePosts() {
+        List<Post> posts = postService.getTruePostTypePosts();
+        return Response.ok(posts);
+    }
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/dto/request/CreatePostRequest.java
@@ -1,0 +1,13 @@
+package com.nemo.dong_geul_be.board.domain.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreatePostRequest {
+    private Boolean isExternal;
+    private String title;
+    private String content;
+    private String hashtag;
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/dto/response/PostDTO.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/dto/response/PostDTO.java
@@ -1,0 +1,16 @@
+package com.nemo.dong_geul_be.board.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostDTO {
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private int commentCount;
+    private Boolean isExternal;
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/dto/response/PostDetailResponse.java
@@ -1,0 +1,18 @@
+package com.nemo.dong_geul_be.board.domain.dto.response;
+
+import com.nemo.dong_geul_be.board.domain.entity.Comment;
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostDetailResponse {
+    private Post post;
+    private List<Comment> comments;
+
+    public PostDetailResponse(Post post, List<Comment> comments) {
+        this.post = post;
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Comment.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Comment.java
@@ -1,0 +1,33 @@
+package com.nemo.dong_geul_be.board.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = true)    //임시로 null값 가능하도록
+    private Member member;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Post.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Post.java
@@ -1,0 +1,48 @@
+package com.nemo.dong_geul_be.board.domain.entity;
+
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = true)
+    private String hashtag;
+
+    @Column(nullable = false)
+    private Boolean postType;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = true)    //임시로 테스트할때 null값 가능하도록
+    private Member member;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private int commentCount;
+
+    @Column(nullable = false)
+    private Boolean isExternal = false;
+
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Post_IMG.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/domain/entity/Post_IMG.java
@@ -1,0 +1,27 @@
+package com.nemo.dong_geul_be.board.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post_IMG {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(nullable = false, length = 50)
+    private String url;  // s3 주소
+
+    @Column(nullable = false)
+    private Boolean state;  // 이미지 존재 여부
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/repository/CommentRepository.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.nemo.dong_geul_be.board.repository;
+
+import com.nemo.dong_geul_be.board.domain.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostId(Long postId);
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/repository/PostRepository.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/repository/PostRepository.java
@@ -1,0 +1,19 @@
+package com.nemo.dong_geul_be.board.repository;
+
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByPostTypeTrue();    // 재잘재잘
+
+    List<Post> findByPostTypeFalse();   // 동글동글
+
+    List<Post> findByIsExternalFalse(); // 교내
+
+    List<Post> findByIsExternalTrue();  // 교외
+
+    List<Post> findByPostTypeFalseAndIsExternalFalse(); // 동글동글, 교내
+
+    List<Post> findByPostTypeFalseAndIsExternalTrue();  // 동글동글, 교외
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/service/CommentService.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/service/CommentService.java
@@ -1,0 +1,43 @@
+package com.nemo.dong_geul_be.board.service;
+
+import com.nemo.dong_geul_be.board.domain.entity.Comment;
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import com.nemo.dong_geul_be.board.repository.CommentRepository;
+import com.nemo.dong_geul_be.board.repository.PostRepository;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final PostService postService;
+
+    //로그인이 아직 없기에 member 지움
+    public Comment createComment(Long postId, String content
+                                 //, Member member
+    ) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("Invalid post ID"));
+
+        Comment comment = Comment.builder()
+                .content(content)
+                .post(post)
+                //.member(member)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        postService.incrementCommentCount(postId);
+
+        return commentRepository.save(comment);
+    }
+
+    public List<Comment> getCommentsByPost(Long postId) {
+        return commentRepository.findByPostId(postId);
+    }
+}

--- a/src/main/java/com/nemo/dong_geul_be/board/service/PostService.java
+++ b/src/main/java/com/nemo/dong_geul_be/board/service/PostService.java
@@ -1,0 +1,98 @@
+package com.nemo.dong_geul_be.board.service;
+
+import com.nemo.dong_geul_be.board.domain.dto.request.CreatePostRequest;
+import com.nemo.dong_geul_be.board.domain.dto.response.PostDTO;
+import com.nemo.dong_geul_be.board.domain.entity.Post;
+import com.nemo.dong_geul_be.board.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    // 재잘재잘 게시글 가져올 때
+    public List<Post> getTruePostTypePosts() {  //재잘재잘
+        return postRepository.findByPostTypeTrue();
+    }
+
+    // 동글동글 게시글 가져올 때
+    public List<PostDTO> getFalsePostTypePosts() {
+        List<Post> posts = postRepository.findByPostTypeFalse();
+        return posts.stream()
+                .map(post -> new PostDTO(       //게시글 목록으로 제목, 내용, 날짜, 댓글 수, 교외/교내 분류
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getCreatedAt(),
+                        post.getCommentCount(),
+                        post.getIsExternal()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 동글동글 게시글이면서 교내 동아리
+    public List<PostDTO> getPostFalseExternalFalsePosts() {
+        List<Post> posts = postRepository.findByPostTypeFalseAndIsExternalFalse();
+        return posts.stream()
+                .map(post -> new PostDTO(
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getCreatedAt(),
+                        post.getCommentCount(),
+                        post.getIsExternal()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 동글동글 게시글이면서 교외 동아리
+    public List<PostDTO> getPostFalseExternalTruePosts() {
+        List<Post> posts = postRepository.findByPostTypeFalseAndIsExternalTrue();
+        return posts.stream()
+                .map(post -> new PostDTO(
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getCreatedAt(),
+                        post.getCommentCount(),
+                        post.getIsExternal()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public Post getPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("게시글을 찾을 수 없습니다."));
+    }
+
+    // 로그인이 없어 우선 테스트로 member 지움
+    // 동글동글 게시판에서 게시글 생성 (post_type = false)
+    public Post createDonggeulPost(CreatePostRequest request
+                                   //, Member member
+    ) {
+        Post post = Post.builder()
+                .isExternal(request.getIsExternal())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .hashtag(request.getHashtag())
+                .postType(false)  // 동글동글 게시판은 무조건 false
+                .createdAt(LocalDateTime.now())
+                //.member(member)
+                .commentCount(0)
+                .build();
+
+        return postRepository.save(post);
+    }
+
+    // 댓글 작성 시 commentCount++
+    public void incrementCommentCount(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Post not found"));
+        post.setCommentCount(post.getCommentCount() + 1);
+        postRepository.save(post);
+    }
+}


### PR DESCRIPTION
#10 

+ BoardDGController, BoardJJController 추가 (각각 동글동글, 재잘재잘)
+ Comment & Post의 Service, Repository 추가
+ Post & Comment & Post_IMG의 Entity 추가

s3를 이용한 Image 업로드와 아직 로그인 기능이 없어 작성 권한,  작성자명과 같은 부분들은 하지 못했습니다.
다른 분들 작업하는데 있어서 게시판이 필요하고 같이 게시판 작업하는학우님을 위해  우선은 동글동글(홍보 게시판2)에 대한 **기본적인 기능 구현**(글 작성, 댓글 작성, 댓글 수 등등)들만 구현하였습니다.

현재는 작성자 member에 대해서 nullable=true를 넣어 로그인하지 않더라도 게시글, 댓글 작성 정도를 가능하게 하였습니다.

추가적으로 수정할 부분 있으면 말씀해주세요.
