### PR TITLE
[Feature] mypage 기능 추가

### DIFF
--- a/src/main/java/com/nemo/dong_geul_be/clubAndHeadmem/ClubAndHeadMem.java
+++ b/src/main/java/com/nemo/dong_geul_be/clubAndHeadmem/ClubAndHeadMem.java
@@ -1,11 +1,12 @@
 package com.nemo.dong_geul_be.clubAndHeadmem;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Setter
@@ -16,6 +17,9 @@ public class ClubAndHeadMem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String clubName;
-    private String studentName;
+    private String managerEmail;
+
+    @OneToMany(mappedBy = "clubAndHeadMem")
+    private List<MyClub> clubMembers= new ArrayList<>();
 
 }

--- a/src/main/java/com/nemo/dong_geul_be/clubAndHeadmem/ClubRepository.java
+++ b/src/main/java/com/nemo/dong_geul_be/clubAndHeadmem/ClubRepository.java
@@ -3,6 +3,9 @@ package com.nemo.dong_geul_be.clubAndHeadmem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ClubRepository extends JpaRepository<ClubAndHeadMem, Long> {
+    Optional<ClubAndHeadMem> findClubAndHeadMemByClubName(String clubName);
 }

--- a/src/main/java/com/nemo/dong_geul_be/csv/CSVDataLoader.java
+++ b/src/main/java/com/nemo/dong_geul_be/csv/CSVDataLoader.java
@@ -28,7 +28,7 @@ public class CSVDataLoader implements CommandLineRunner {
                 String studentName = line[1].trim();
                 ClubAndHeadMem club = new ClubAndHeadMem();
                 club.setClubName(clubName);
-                club.setStudentName(studentName);
+                club.setManagerEmail(studentName);
                 clubRepository.save(club);
             }
         }

--- a/src/main/java/com/nemo/dong_geul_be/member/domain/entity/Member.java
+++ b/src/main/java/com/nemo/dong_geul_be/member/domain/entity/Member.java
@@ -1,17 +1,9 @@
 package com.nemo.dong_geul_be.member.domain.entity;
 
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import jakarta.persistence.*;
 import org.hibernate.annotations.SQLRestriction;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -19,6 +11,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Entity
@@ -52,6 +47,9 @@ public class Member {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "auth_code")
 	private AuthCode authCode;
+
+	@OneToMany(mappedBy = "member")
+	private List<MyClub> myClubs = new ArrayList<>();
 
 	public void updatePassword(String encryptPassword) {
 		this.password = encryptPassword;

--- a/src/main/java/com/nemo/dong_geul_be/member/domain/entity/Role.java
+++ b/src/main/java/com/nemo/dong_geul_be/member/domain/entity/Role.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Role {
 
-	MEMBER("MEMBER");
+	MEMBER("MEMBER"), MANAGER("MANAGER");
 
 	private final String role;
 

--- a/src/main/java/com/nemo/dong_geul_be/mypage/MyPageConverter.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/MyPageConverter.java
@@ -1,0 +1,70 @@
+package com.nemo.dong_geul_be.mypage;
+
+import com.nemo.dong_geul_be.clubAndHeadmem.ClubAndHeadMem;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import com.nemo.dong_geul_be.mypage.domain.IsConfirmed;
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import com.nemo.dong_geul_be.mypage.dto.MyPageRequest;
+import com.nemo.dong_geul_be.mypage.dto.MyPageResponse;
+
+import java.util.List;
+
+public class MyPageConverter {
+
+
+    public static MyPageResponse.MyPageDTO toMyPageDTO(Member member,List<MyClub> clubRequests, List<ClubAndHeadMem> clubAndHeadMems) {
+            //마이페이지 정보 변환
+            return MyPageResponse.MyPageDTO.builder()
+                    .nickName(member.getNickname())
+                    .email(member.getEmail())
+                    .role(member.getRole())
+                    .myClubList(toMyClubDTOList(member.getMyClubs()))
+                    .waitingMemberList(toWaitingClubMemberDTOList(clubRequests))
+                    .allClubList(toAllClubDTOList(clubAndHeadMems))
+                    .build();
+    }
+
+    private static List<MyPageResponse.ClubDTO> toMyClubDTOList(List<MyClub> myClubs) {
+        // 가입한 동아리 이름 리스트 응답 정보 변환
+        return myClubs.stream()
+                .map(myClub -> MyPageResponse.ClubDTO.builder()
+                        .clubName(myClub.getClubAndHeadMem().getClubName())
+                        .isConfirmed(myClub.getIsConfirmed())
+                        .build())
+                .toList();
+    }
+
+    private static List<MyPageResponse.ClubDTO> toAllClubDTOList(List<ClubAndHeadMem> clubAndHeadMems){
+        // 전체 동아리 이름 리스트 응답 정보 변환
+        return clubAndHeadMems.stream()
+                .map(clubAndHeadMem -> MyPageResponse.ClubDTO.builder()
+                        .clubName(clubAndHeadMem.getClubName())
+                        .build())
+                .toList();
+    }
+
+    private static List<MyPageResponse.WaitingClubMemberDTO> toWaitingClubMemberDTOList(List<MyClub> clubRequests) {
+        // 요청 수락 대기중인 회원 리스트 응답 정보 변환
+
+        return clubRequests.stream()
+                .map(myClub -> MyPageResponse.WaitingClubMemberDTO.builder()
+                        .name(myClub.getName())
+                        .email(myClub.getMember().getEmail()) //
+                        .isConfirmed(myClub.getIsConfirmed())
+                        .studentId(myClub.getStudentId())
+                        .build())
+                .toList();
+    }
+
+    public static MyClub toMyClub(Member member, ClubAndHeadMem clubAndHeadMem, MyPageRequest.MyClubRequest request) {
+        // 가입 요청
+        return MyClub.builder()
+                .isConfirmed(IsConfirmed.WAITING) // 가입 대기 상태로 설정
+                .clubAndHeadMem(clubAndHeadMem)
+                .name(request.getName()) // 이름 설정
+                .member(member)
+                .studentId(request.getStudentId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/controller/MyPageController.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/controller/MyPageController.java
@@ -1,0 +1,53 @@
+package com.nemo.dong_geul_be.mypage.controller;
+
+
+import com.nemo.dong_geul_be.global.response.Response;
+import com.nemo.dong_geul_be.mypage.dto.MyPageRequest;
+import com.nemo.dong_geul_be.mypage.dto.MyPageResponse;
+import com.nemo.dong_geul_be.mypage.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+    private final MyPageService mypageService;
+
+    @Operation(summary = "마이 페이지", description = "마이페이지 필요 정보를 반환합니다.")
+    @GetMapping("")
+    public ResponseEntity<MyPageResponse.MyPageDTO> getMyPageInfo(@RequestParam Long memberId){
+        MyPageResponse.MyPageDTO mypageDTO = mypageService.getMyPageInfo(memberId);
+
+        return ResponseEntity.ok(mypageDTO);
+    }
+
+    @Operation(summary = "동아리 요청", description = "동아리 가입 요청을 합니다.")
+    @PostMapping("/club-request")
+    public ResponseEntity<Void> requestClubJoin(@RequestParam Long memberId,@RequestBody MyPageRequest.MyClubRequest clubRequest){
+        // 동아리 가입 요청
+        mypageService.requestClubJoin(memberId,clubRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "동아리 승인", description = "동아리 가입을 승인합니다.")
+    @PostMapping("/club-accept")
+    public ResponseEntity<Void> confirmClubJoin(@RequestBody MyPageRequest.ConfirmOrRejectRequest clubRequest){
+        // 동아리 가입
+        mypageService.acceptClubJoin(clubRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "동아리 거절", description = "동아리 가입을 거절합니다.")
+    @PostMapping("/club-reject")
+    public ResponseEntity<Void> rejectClubJoin(@RequestBody MyPageRequest.ConfirmOrRejectRequest clubRequest){
+        // 동아리 가입 거절
+        mypageService.rejectClubJoin(clubRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/domain/IsConfirmed.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/domain/IsConfirmed.java
@@ -1,0 +1,5 @@
+package com.nemo.dong_geul_be.mypage.domain;
+
+public enum IsConfirmed {
+    WAITING, REJECT, JOIN
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/domain/MyClub.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/domain/MyClub.java
@@ -1,0 +1,52 @@
+package com.nemo.dong_geul_be.mypage.domain;
+
+
+import com.nemo.dong_geul_be.clubAndHeadmem.ClubAndHeadMem;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyClub {
+
+        @Id
+        @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+        private Long id;
+
+        @NotNull
+        private String name;
+
+        @NotNull
+        private String studentId;
+
+        @Enumerated(EnumType.STRING)
+        @Column(nullable = false)
+        private IsConfirmed isConfirmed;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "clubAndHeadMem_id")
+        private ClubAndHeadMem clubAndHeadMem;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "member_id")
+        private Member member;
+
+        public void confirmMember() {
+                if (this.isConfirmed == IsConfirmed.JOIN) {
+                        throw new IllegalStateException("Member is already JOIN.");
+                }
+                this.isConfirmed = IsConfirmed.JOIN; // IsConfirmed.CONFIRMED로 변경
+        }
+
+        public void cancelMember() {
+                if (this.isConfirmed == IsConfirmed.REJECT) {
+                        throw new IllegalStateException("Member is already CANCEL.");
+                }
+                this.isConfirmed = IsConfirmed.REJECT; // IsConfirmed.CANCEL로 변경
+        }
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/dto/MyPageRequest.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/dto/MyPageRequest.java
@@ -1,0 +1,29 @@
+package com.nemo.dong_geul_be.mypage.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class MyPageRequest {
+
+    @Getter
+    public static class  MyClubRequest {
+        @NotNull(message = "동아리 이름")
+        private String clubName;
+
+        @NotNull(message = "학번")
+        private String studentId;
+
+        @NotNull(message = "이름")
+        private String name;
+    }
+
+    @Getter
+    public static class ConfirmOrRejectRequest{
+        @NotNull
+        private String email;
+        @NotNull
+        private String clubName;
+    }
+
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/dto/MyPageResponse.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/dto/MyPageResponse.java
@@ -1,0 +1,53 @@
+package com.nemo.dong_geul_be.mypage.dto;
+
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import com.nemo.dong_geul_be.member.domain.entity.Role;
+import com.nemo.dong_geul_be.mypage.domain.IsConfirmed;
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import lombok.*;
+
+import java.util.List;
+
+public class MyPageResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyPageDTO{
+        String nickName;
+        String email;
+        //운영진 여부
+        Role role;
+        //가입한 동아리 리스트
+        List<ClubDTO> myClubList;
+        //요청 수락 대기중인 회원 리스트
+        List<WaitingClubMemberDTO> waitingMemberList;
+        //전체 동아리 이름 리스트
+        List<ClubDTO> allClubList;
+        //현재 관리하는 동아리 이름
+        String currentClubName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubDTO{
+        //가입한 동아리 (개별)
+        String clubName;
+        IsConfirmed isConfirmed;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WaitingClubMemberDTO{
+        String name;
+        String email;
+        String studentId;
+        IsConfirmed isConfirmed;
+    }
+
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/repository/MyClubRepository.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/repository/MyClubRepository.java
@@ -1,0 +1,27 @@
+package com.nemo.dong_geul_be.mypage.repository;
+
+import com.nemo.dong_geul_be.clubAndHeadmem.ClubAndHeadMem;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import com.nemo.dong_geul_be.mypage.domain.IsConfirmed;
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MyClubRepository extends JpaRepository<MyClub, Long> {
+
+    // 이미 MyClub에 있는지 확인하는 메서드
+    @Query("SELECT COUNT(mc) > 0 FROM MyClub mc WHERE mc.member = :member AND mc.clubAndHeadMem = :clubAndHeadMem")
+    boolean existsByMemberAndClub(@Param("member") Member member, @Param("clubAndHeadMem") ClubAndHeadMem clubAndHeadMem);
+
+
+    // 특정 운영진이 관리하는 동아리로 온 상태가 WAITING인 MyClub 목록 조회
+    @Query("SELECT mc FROM MyClub mc WHERE mc.clubAndHeadMem.managerEmail = :managerEmail AND mc.isConfirmed = :status")
+    List<MyClub> findByClubAndHeadMemAndIsConfirmed(@Param("managerEmail") String managerEmail, @Param("status") IsConfirmed status);
+
+    @Query("SELECT mc FROM MyClub mc WHERE mc.member = :member AND mc.clubAndHeadMem = :clubAndHeadMem")
+    Optional<MyClub> findByMemberAndClubAndHeadMem(@Param("member") Member member, @Param("clubAndHeadMem") ClubAndHeadMem clubAndHeadMem);
+}

--- a/src/main/java/com/nemo/dong_geul_be/mypage/service/MyPageService.java
+++ b/src/main/java/com/nemo/dong_geul_be/mypage/service/MyPageService.java
@@ -1,0 +1,117 @@
+package com.nemo.dong_geul_be.mypage.service;
+
+
+import com.nemo.dong_geul_be.clubAndHeadmem.ClubAndHeadMem;
+import com.nemo.dong_geul_be.clubAndHeadmem.ClubRepository;
+import com.nemo.dong_geul_be.global.exception.BusinessException;
+import com.nemo.dong_geul_be.global.exception.GlobalExceptionHandler;
+import com.nemo.dong_geul_be.global.response.Code;
+import com.nemo.dong_geul_be.member.domain.entity.Member;
+import com.nemo.dong_geul_be.member.domain.entity.Role;
+import com.nemo.dong_geul_be.member.repository.MemberRepository;
+import com.nemo.dong_geul_be.mypage.MyPageConverter;
+import com.nemo.dong_geul_be.mypage.domain.IsConfirmed;
+import com.nemo.dong_geul_be.mypage.domain.MyClub;
+import com.nemo.dong_geul_be.mypage.dto.MyPageRequest;
+import com.nemo.dong_geul_be.mypage.dto.MyPageResponse;
+import com.nemo.dong_geul_be.mypage.repository.MyClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private static final Logger logger = LoggerFactory.getLogger(MyPageService.class);
+
+    private final MemberRepository memberRepository;
+    private final MyClubRepository myClubRepository;
+    private final ClubRepository clubAndHeadMemRepository;
+
+    public MyPageResponse.MyPageDTO getMyPageInfo(Long memberId) {
+        //회원 정보 조회
+        Member member= memberRepository.findById(memberId).orElseThrow(RuntimeException::new);
+        List<MyClub> clubRequests = new ArrayList<>(); // 기본값 null로 초기화
+        logger.info("Member role: {}", member.getRole());
+        // member가 운영진이면 운영진 정보 조회
+        if (member.getRole() == Role.MANAGER) {
+            logger.info("MANAGER: 운영진 정보 조회");
+            clubRequests = getWaitingRequests(member);
+        }
+
+        return MyPageConverter.toMyPageDTO(member, clubRequests, clubAndHeadMemRepository.findAll());
+    }
+
+    public List<MyClub> getWaitingRequests(Member member) {
+        // 동아리 관리자로 등록된 동아리의 대기 중인 요청을 가져오는 쿼리
+        logger.info("Fetching waiting requests for member with email: {}", member.getEmail());
+        return myClubRepository.findByClubAndHeadMemAndIsConfirmed(member.getEmail(), IsConfirmed.WAITING);
+    }
+
+    @Transactional
+    // 동아리 가입 요청
+    public void requestClubJoin(Long memberId,MyPageRequest.MyClubRequest clubRequest){
+        // 동아리 가입 요청
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
+        ClubAndHeadMem clubAndHeadMem = clubAndHeadMemRepository.findClubAndHeadMemByClubName(clubRequest.getClubName())
+                .orElseThrow(() ->  new IllegalStateException("해당 동아리가 존재하지 않습니다."));
+
+        //운영진 계정 있는지 확인
+        Member headMember = memberRepository.findMemberByEmail(clubAndHeadMem.getManagerEmail())
+                .orElseThrow(() ->  new IllegalStateException("운영진 계정이 없습니다."));
+
+        // 이미 요청이 있는지 확인
+        if (myClubRepository.existsByMemberAndClub(member, clubAndHeadMem)) {
+            throw new IllegalStateException("이미 처리된 동아리입니다.");
+        }
+
+        MyClub myClub = MyPageConverter.toMyClub(member, clubAndHeadMem, clubRequest);
+        myClubRepository.save(myClub);
+
+    }
+
+    @Transactional
+    // 동아리 가입 요청 승인
+    public void acceptClubJoin(MyPageRequest.ConfirmOrRejectRequest confirmRequest){
+
+        Member member = memberRepository.findMemberByEmail(confirmRequest.getEmail())
+                .orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
+
+        ClubAndHeadMem clubAndHeadMem = clubAndHeadMemRepository.findClubAndHeadMemByClubName(confirmRequest.getClubName())
+                .orElseThrow(() ->  new IllegalStateException("해당 동아리가 존재하지 않습니다."));
+
+        MyClub myClub = myClubRepository.findByMemberAndClubAndHeadMem(member, clubAndHeadMem)
+                .orElseThrow(RuntimeException::new);
+
+        //승인 처리
+        myClub.confirmMember();
+        myClubRepository.save(myClub);
+
+    }
+
+    @Transactional
+    // 동아리 가입 요청 거절
+    public void rejectClubJoin(MyPageRequest.ConfirmOrRejectRequest rejectRequest){
+
+        Member member = memberRepository.findMemberByEmail(rejectRequest.getEmail())
+                .orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
+        //동아리 이름으로 동아리 조회
+        ClubAndHeadMem clubAndHeadMem = clubAndHeadMemRepository.findClubAndHeadMemByClubName(rejectRequest.getClubName())
+                .orElseThrow(() ->  new IllegalStateException("해당 동아리가 존재하지 않습니다."));
+
+        //회원, 동아리, 운영진으로 MyClub 조회
+        MyClub myClub = myClubRepository.findByMemberAndClubAndHeadMem(member, clubAndHeadMem)
+                .orElseThrow(RuntimeException::new);
+        //거절 처리
+        myClub.cancelMember();
+        myClubRepository.save(myClub);
+
+    }
+}

--- a/src/main/resources/csv/club.csv
+++ b/src/main/resources/csv/club.csv
@@ -1,2 +1,2 @@
-UMC,202021165
-멋쟁이 사자처럼,202021185
+UMC,umcManager@catholic.com
+멋쟁이 사자처럼,lionManager@catholic.com


### PR DESCRIPTION
전처리 수정 ClubAndHeadmem
1-1 csv 정보 학번에서 이메일로 수정
1-2 ClubAndHeadmem --* MyClub 일대다 매핑

Member 추가 사항
2-1 Member Role에 MANAGER 추가
2-2 Member --* MyClub 일대다 매핑

MyPage 구현
3-1 정보 반환 :  이메일, 닉네임, 역할(member or manager), 가입 동아리 리스트, 전체 동아리 리스트, 자신이 관리하는 동아리의 가입 요청 리스트
3-2 가입 요청 : 운영진에게 가입 요청
3-3 가입 승인 : 요청 온 리스트에서 해당 메일의 MyClub 상태를 join으로 변환
3-4 가입 거절 : 요청 온 리스트에서 해당 메일의 MyClub 상태를 reject으로 변환

임시로 파라미터 memberId 입력받아서 작동되도록 해놨습니다.  제대로 잘 작성한 건지 모르겠네요,,, 수정사항이나 추가사항 있으면 말해주세요